### PR TITLE
Update webpack config file

### DIFF
--- a/webpack/src/utils.ts
+++ b/webpack/src/utils.ts
@@ -74,26 +74,32 @@ export function getWebpackConfig () {
 
     module.exports = {
       entry: './${appPath}/index.js',
-      devtool: 'source-map',
-      resolve: {
-        extensions: ['', '.js', '.jsx']
-      },
       output: {
         filename: 'bundle.js',
         path: path.resolve(__dirname, '${bundlePath}')
       },
       module: {
-        loaders: [
+        rules: [
           {
-            test: /\.js$/,
-            exclude: /(node_modules|bower_components)/,
-            loader: 'babel', // 'babel-loader' is also a valid name to reference
+            test: /\.jsx?$/,
+            include: [
+              path.resolve(__dirname, 'app')
+            ]
+            exclude: [
+              path.resolve(__dirname, 'node_modules'),
+              path.resolve(__dirname, 'bower_components')
+            ],
+            loader: 'babel-loader',
             query: {
               presets: ['es2015']
             }
           }
         ]
-      }
+      },
+      resolve: {
+        extensions: ['.json', '.js', '.jsx', '.css']
+      },
+      devtool: 'source-map'
     };
   `;
 }


### PR DESCRIPTION
I realized that I make the same changes/udpates to the auto-generated webpack config file and I thought it would be best to contribute it upstream.

- Rename module.loaders to `module.rules` to comply with webpack v2.
- Fix test regex from `\.js$` `\.jsx?$` (will match on `.js` or `.jsx`)
- Add `rule.include` (array of paths)
- Change `rule.exclude` to array of paths rather than regex
- Fix `rule.loader` from `babel` to `babel-loader` as webpack v2 complains about `babel`,
- Remove empty/blank resolve.extensions (e.g. `''`) as webpack v2 complains about it
- Add `.css` to resolve.extensions