### PR TITLE
Remove link to expired domain

### DIFF
--- a/extensions/vscode-lebab/README.md
+++ b/extensions/vscode-lebab/README.md
@@ -2,8 +2,6 @@
 
 Converts ES5 javascript to ES6 using lebab.
 
-https://lebab.io/try-it
-
 Link: https://marketplace.visualstudio.com/items?itemName=jeremyrajan.vscode-lebab
 
 ## Usage


### PR DESCRIPTION
Looks like this domain has changed hands or has changed purposes. This small PR removes this link from the Readme.